### PR TITLE
Corrrect token URL

### DIFF
--- a/_authentication.md
+++ b/_authentication.md
@@ -31,7 +31,7 @@ We recommend people secure Personal Access Tokens like you would a password. The
 > To create a Personal Access Token, execute the following command:
 
 ```bash
-curl https://api.bitreserve.org/oauth2/token \
+curl https://api.bitreserve.org/oauth2/tokens \
   -X POST \
   -H 'X-Bitreserve-OTP: <OTP-Token>' \
   -H "Content-Type: application/json" \


### PR DESCRIPTION
It seems that the working url to request a token is `oauth2/tokens` and not `oauth2/token`.