### PR TITLE
Update pagination documentation

### DIFF
--- a/_pagination.md
+++ b/_pagination.md
@@ -1,6 +1,6 @@
 # Pagination
 
-All collection endpoints support [Range Pagination Headers](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html) using `Range` & `Content-Range` entity-headers.
+ Collection endpoints with large dataset supports [Range Pagination Headers](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html) using `Range` & `Content-Range` entity-headers.
 
 ## Request
 


### PR DESCRIPTION
This specifies that pagination is supported only in collection endpoints where the total number of items are too long and extensive to be presented in a single page/result.